### PR TITLE
Making the change to be compatible without breaking changes to config

### DIFF
--- a/cmd/moss/structs.go
+++ b/cmd/moss/structs.go
@@ -105,6 +105,8 @@ func (c *Conf) getConfig(confPath string) (*Conf, error) {
 		log.Fatal().Err(err).Msg("failed to unmarshal config file")
 		return &Conf{}, err
 	}
+	// Set default organization types
+	c.setDefaultOrgTypes()
 	// Validate organization names are unique
 	if err := c.validateUniqueOrgNames(); err != nil {
 		log.Fatal().Err(err).Msg("organization validation failed")
@@ -167,4 +169,18 @@ func (c *Conf) buildSecretIgnores() {
 		ignore_patterns = append(ignore_patterns, re)
 	}
 	c.s_ignores = ignore_patterns
+}
+
+func (c *Conf) setDefaultOrgTypes() {
+	// Set default organization type to "cloud" for GitHub and GitLab if not specified
+	for i, org := range c.GithubConfig.OrgsToScan {
+		if org.Type == "" {
+			c.GithubConfig.OrgsToScan[i].Type = "cloud"
+		}
+	}
+	for i, org := range c.GitlabConfig.OrgsToScan {
+		if org.Type == "" {
+			c.GitlabConfig.OrgsToScan[i].Type = "cloud"
+		}
+	}
 }

--- a/cmd/moss/structs_test.go
+++ b/cmd/moss/structs_test.go
@@ -17,7 +17,7 @@ func TestConfigParsing(t *testing.T) {
 	var conf Conf
 	conf.getConfig(confpath)
 	// make sure it parsed correctly
-	if len(conf.GithubConfig.OrgsToScan) != 2 {
+	if len(conf.GithubConfig.OrgsToScan) != 3 {
 		t.Errorf("orgs to scan didn't load correctly. Got a len of: %d", len(conf.GithubConfig.OrgsToScan))
 	}
 	if conf.GithubConfig.DaysToScan != 30 {

--- a/configs/conf.yml
+++ b/configs/conf.yml
@@ -4,6 +4,7 @@ github_config:
     # 'name' usually refers to the GitLab organization identifier, but can be set independently for cross-platform consistency
     - name: LivingInSynTestOrg
       type: cloud
+    - name: LivingInSynTestOrg2
   # if set to > 1 it will scan repos pushed to in the last `n` days, 
   # if set to <= 0, it will scan all repos, might be a lot of repos!
   days_to_scan: 30
@@ -16,6 +17,7 @@ gitlab_config:
       base_url: https://gitlab.test-org.com
     - name: testOrg2
       type: cloud
+    - name: testOrg3
     # this is an array of gitlab orgs to scan
   days_to_scan: 20
 

--- a/configs/test_conf.yml
+++ b/configs/test_conf.yml
@@ -6,6 +6,7 @@ github_config:
       type: cloud
     - name: LivingInSynTestOrg2
       type: onprem
+    - name: LivingInSynTestOrg3
   # if set to > 1 it will scan repos pushed to in the last `n` days, 
   # if set to <= 0, it will scan all repos, might be a lot of repos!
   days_to_scan: 30
@@ -18,6 +19,7 @@ gitlab_config:
       base_url: https://gitlab.<org_name>.com
     - name: testorg4
       type: cloud
+    - name: testorg5
     # this is an array of gitlab orgs to scan
   days_to_scan: 20
 


### PR DESCRIPTION
Made the config compatible to accept the orgs just with just an orgname without type/url by making cloud as default provider type